### PR TITLE
feat: add ErrorBoundary to STL viewer

### DIFF
--- a/src/web/components/3d-viewer/StlViewer.tsx
+++ b/src/web/components/3d-viewer/StlViewer.tsx
@@ -4,6 +4,7 @@ import { Suspense } from 'react';
 import { Canvas } from '@react-three/fiber';
 import { OrbitControls, Environment } from '@react-three/drei';
 import { StlModel } from './StlModel';
+import { StlViewerErrorBoundary } from './StlViewerErrorBoundary';
 
 interface StlViewerProps {
   url: string;
@@ -21,25 +22,27 @@ function LoadingFallback() {
 
 export function StlViewer({ url, className }: StlViewerProps) {
   return (
-    <div className={className ?? 'w-full h-[400px] rounded-lg overflow-hidden bg-slate-50 border'}>
-      <Canvas
-        camera={{ position: [5, 3, 5], fov: 50 }}
-        gl={{ antialias: true }}
-      >
-        <ambientLight intensity={0.5} />
-        <directionalLight position={[10, 10, 5]} intensity={1} />
-        <directionalLight position={[-10, -10, -5]} intensity={0.3} />
-        <Suspense fallback={<LoadingFallback />}>
-          <Environment preset="studio" />
-          <StlModel url={url} />
-        </Suspense>
-        <OrbitControls
-          makeDefault
-          enablePan={true}
-          enableZoom={true}
-          enableRotate={true}
-        />
-      </Canvas>
-    </div>
+    <StlViewerErrorBoundary resetKey={url}>
+      <div className={className ?? 'w-full h-[400px] rounded-lg overflow-hidden bg-slate-50 border'}>
+        <Canvas
+          camera={{ position: [5, 3, 5], fov: 50 }}
+          gl={{ antialias: true }}
+        >
+          <ambientLight intensity={0.5} />
+          <directionalLight position={[10, 10, 5]} intensity={1} />
+          <directionalLight position={[-10, -10, -5]} intensity={0.3} />
+          <Suspense fallback={<LoadingFallback />}>
+            <Environment preset="studio" />
+            <StlModel url={url} />
+          </Suspense>
+          <OrbitControls
+            makeDefault
+            enablePan={true}
+            enableZoom={true}
+            enableRotate={true}
+          />
+        </Canvas>
+      </div>
+    </StlViewerErrorBoundary>
   );
 }

--- a/src/web/components/3d-viewer/StlViewerErrorBoundary.tsx
+++ b/src/web/components/3d-viewer/StlViewerErrorBoundary.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { Component, ReactNode } from 'react';
+import { AlertTriangle, RefreshCw } from 'lucide-react';
+
+interface Props {
+  children: ReactNode;
+  /** When this value changes the boundary resets automatically (pass the model URL). */
+  resetKey?: string;
+}
+
+interface State {
+  hasError: boolean;
+  errorMessage: string | null;
+}
+
+export class StlViewerErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, errorMessage: null };
+  }
+
+  static getDerivedStateFromError(error: unknown): State {
+    const message =
+      error instanceof Error ? error.message : 'An unexpected error occurred.';
+    return { hasError: true, errorMessage: message };
+  }
+
+  componentDidCatch(error: unknown, info: { componentStack: string }) {
+    // Surface to console so it still shows in dev tools / Sentry if wired up.
+    console.error('[StlViewer] Render error:', error, info.componentStack);
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    // Auto-reset when the URL (resetKey) changes so a new file gets a fresh attempt.
+    if (this.state.hasError && prevProps.resetKey !== this.props.resetKey) {
+      this.setState({ hasError: false, errorMessage: null });
+    }
+  }
+
+  handleRetry = () => {
+    this.setState({ hasError: false, errorMessage: null });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return <StlViewerFallback onRetry={this.handleRetry} message={this.state.errorMessage} />;
+    }
+
+    return this.props.children;
+  }
+}
+
+interface FallbackProps {
+  onRetry: () => void;
+  message: string | null;
+}
+
+function StlViewerFallback({ onRetry, message }: FallbackProps) {
+  const isWebGl = message?.toLowerCase().includes('webgl');
+
+  return (
+    <div className="w-full h-full min-h-[200px] flex flex-col items-center justify-center gap-3 bg-slate-50 text-slate-500 rounded-lg border border-dashed border-slate-200 p-6">
+      <AlertTriangle className="w-8 h-8 text-amber-400 shrink-0" />
+
+      <div className="text-center space-y-1">
+        <p className="text-sm font-medium text-slate-700">
+          {isWebGl ? 'WebGL not available' : 'Unable to load 3D preview'}
+        </p>
+        <p className="text-xs text-slate-400 max-w-[260px]">
+          {isWebGl
+            ? 'Your browser or device does not support WebGL. Try a different browser.'
+            : 'The file may be corrupted or in an unsupported format. You can still proceed with your order.'}
+        </p>
+      </div>
+
+      {!isWebGl && (
+        <button
+          onClick={onRetry}
+          className="inline-flex items-center gap-1.5 text-xs text-slate-500 hover:text-slate-700 underline underline-offset-2 transition-colors"
+        >
+          <RefreshCw className="w-3 h-3" />
+          Try again
+        </button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## What changed
Adds an error boundary around the STL viewer so render failures (corrupt files, 404s, WebGL unavailability, network blips) show a recoverable fallback UI instead of crashing the page. Auto-resets when a new file URL is passed in, and detects WebGL failures to show a browser-specific message without a misleading retry button.

## Related issue
Closes #28

## Type of change
- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `chore` — refactor, deps, tooling (no behaviour change)
- [ ] `docs` — documentation only

## How to test
1. Upload a valid STL file on the upload page — viewer renders normally
2. Rename a `.txt` file to `.stl` and upload it — fallback UI appears with a "Try again" button
3. Click "Try again" — boundary resets and attempts to reload
4. Upload a valid file after an error — boundary auto-resets without any manual action
5. Verify the portfolio detail page and admin media upload field are also protected (no crash on a bad model URL)

## Checklist
- [ ] CI passes (build, lint, tests)
- [x] No hardcoded secrets or credentials
- [x] New environment variables documented in `appsettings.json` / `.env.example`
- [x] Database migrations included if schema changed