### PR TITLE
chore: extract shared form primitives and groupMaterials utility

### DIFF
--- a/src/web/app/(dashboard)/orders/new/page.tsx
+++ b/src/web/app/(dashboard)/orders/new/page.tsx
@@ -38,8 +38,6 @@ const QUALITY_OPTIONS = [
 
 // ── Shared field primitives ───────────────────────────────────────────────────
 
-const inputCls = `w-full h-9 bg-surface-alt border border-border px-3 text-[11px] text-text-primary placeholder:text-text-muted focus:outline-none focus:border-accent transition-colors`;
-const textareaCls = `w-full bg-surface-alt border border-border px-3 py-2.5 text-[11px] text-text-primary placeholder:text-text-muted focus:outline-none focus:border-accent transition-colors resize-none`;
 
 function FieldLabel({ children, optional }: { children: React.ReactNode; optional?: boolean }) {
   return (
@@ -178,7 +176,7 @@ export default function NewOrderPage() {
             <div className="relative">
               <select
                 {...register('materialId')}
-                className={`${inputCls} ${mono.className} appearance-none pr-8`}
+                className={`field-input-alt ${mono.className} appearance-none pr-8`}
               >
                 <option value="">Select a material</option>
                 {materialsData?.data.map(m => (
@@ -201,7 +199,7 @@ export default function NewOrderPage() {
               <input
                 type="number"
                 min={1}
-                className={`${inputCls} ${mono.className}`}
+                className={`field-input-alt ${mono.className}`}
                 {...register('quantity', { valueAsNumber: true })}
               />
               <FieldError msg={errors.quantity?.message} />
@@ -212,7 +210,7 @@ export default function NewOrderPage() {
                 type="number"
                 min={5}
                 max={100}
-                className={`${inputCls} ${mono.className}`}
+                className={`field-input-alt ${mono.className}`}
                 {...register('infill', { valueAsNumber: true })}
               />
               <FieldError msg={errors.infill?.message} />
@@ -263,7 +261,7 @@ export default function NewOrderPage() {
             <textarea
               rows={3}
               placeholder="Any specific requirements for this print..."
-              className={`${textareaCls} ${mono.className}`}
+              className={`field-textarea-alt ${mono.className}`}
               {...register('specialInstructions')}
             />
           </div>
@@ -285,7 +283,7 @@ export default function NewOrderPage() {
             <textarea
               rows={3}
               placeholder="Enter your full shipping address..."
-              className={`${textareaCls} ${mono.className}`}
+              className={`field-textarea-alt ${mono.className}`}
               {...register('shippingAddress')}
             />
             <FieldError msg={errors.shippingAddress?.message} />
@@ -296,7 +294,7 @@ export default function NewOrderPage() {
             <textarea
               rows={2}
               placeholder="Anything else we should know..."
-              className={`${textareaCls} ${mono.className}`}
+              className={`field-textarea-alt ${mono.className}`}
               {...register('notes')}
             />
           </div>

--- a/src/web/app/(dashboard)/profile/page.tsx
+++ b/src/web/app/(dashboard)/profile/page.tsx
@@ -42,7 +42,6 @@ type PasswordFormValues = z.infer<typeof passwordSchema>;
 
 // ── Shared primitives ─────────────────────────────────────────────────────────
 
-const inputCls = `w-full h-9 bg-surface-alt border border-border px-3 text-[11px] text-text-primary placeholder:text-text-muted focus:outline-none focus:border-accent transition-colors`;
 
 function FieldLabel({ children }: { children: React.ReactNode }) {
   return (
@@ -130,12 +129,12 @@ function ProfileForm({ user }: {
         <div className="grid grid-cols-2 gap-4">
           <div>
             <FieldLabel>First Name</FieldLabel>
-            <input className={`${inputCls} ${mono.className}`} {...register('firstName')} />
+            <input className={`field-input-alt ${mono.className}`} {...register('firstName')} />
             <FieldError msg={errors.firstName?.message} />
           </div>
           <div>
             <FieldLabel>Last Name</FieldLabel>
-            <input className={`${inputCls} ${mono.className}`} {...register('lastName')} />
+            <input className={`field-input-alt ${mono.className}`} {...register('lastName')} />
             <FieldError msg={errors.lastName?.message} />
           </div>
         </div>
@@ -143,7 +142,7 @@ function ProfileForm({ user }: {
         <div>
           <FieldLabel>Phone Number</FieldLabel>
           <input
-            className={`${inputCls} ${mono.className}`}
+            className={`field-input-alt ${mono.className}`}
             placeholder="+1 (555) 000-0000"
             {...register('phoneNumber')}
           />
@@ -152,7 +151,7 @@ function ProfileForm({ user }: {
         <div>
           <FieldLabel>Company Name</FieldLabel>
           <input
-            className={`${inputCls} ${mono.className}`}
+            className={`field-input-alt ${mono.className}`}
             placeholder="Your company (optional)"
             {...register('companyName')}
           />
@@ -207,19 +206,19 @@ function PasswordForm() {
       <form onSubmit={handleSubmit(v => mutation.mutate(v))} className="space-y-4">
         <div>
           <FieldLabel>Current Password</FieldLabel>
-          <PasswordInput className={`${inputCls} ${mono.className}`} {...register('currentPassword')} />
+          <PasswordInput className={`field-input-alt ${mono.className}`} {...register('currentPassword')} />
           <FieldError msg={errors.currentPassword?.message} />
         </div>
 
         <div>
           <FieldLabel>New Password</FieldLabel>
-          <PasswordInput className={`${inputCls} ${mono.className}`} {...register('newPassword')} />
+          <PasswordInput className={`field-input-alt ${mono.className}`} {...register('newPassword')} />
           <FieldError msg={errors.newPassword?.message} />
         </div>
 
         <div>
           <FieldLabel>Confirm New Password</FieldLabel>
-          <PasswordInput className={`${inputCls} ${mono.className}`} {...register('confirmPassword')} />
+          <PasswordInput className={`field-input-alt ${mono.className}`} {...register('confirmPassword')} />
           <FieldError msg={errors.confirmPassword?.message} />
         </div>
 

--- a/src/web/app/(dashboard)/quotes/new/page.tsx
+++ b/src/web/app/(dashboard)/quotes/new/page.tsx
@@ -29,8 +29,6 @@ type QuoteFormValues = z.infer<typeof quoteSchema>;
 
 // ── Shared primitives ─────────────────────────────────────────────────────────
 
-const inputCls = `w-full h-9 bg-surface-alt border border-border px-3 text-[11px] text-text-primary placeholder:text-text-muted focus:outline-none focus:border-accent transition-colors`;
-const textareaCls = `w-full bg-surface-alt border border-border px-3 py-2.5 text-[11px] text-text-primary placeholder:text-text-muted focus:outline-none focus:border-accent transition-colors resize-none`;
 
 function FieldLabel({ children, optional }: { children: React.ReactNode; optional?: boolean }) {
   return (
@@ -147,7 +145,7 @@ export default function NewQuotePage() {
             <input
               type="number"
               min={1}
-              className={`${inputCls} ${mono.className}`}
+              className={`field-input-alt ${mono.className}`}
               {...register('quantity', { valueAsNumber: true })}
             />
             <FieldError msg={errors.quantity?.message} />
@@ -158,7 +156,7 @@ export default function NewQuotePage() {
             <div className="relative">
               <select
                 {...register('preferredMaterialId')}
-                className={`${inputCls} ${mono.className} appearance-none pr-8`}
+                className={`field-input-alt ${mono.className} appearance-none pr-8`}
               >
                 <option value="">No preference</option>
                 {materialsData?.data.map(m => (
@@ -175,7 +173,7 @@ export default function NewQuotePage() {
             <FieldLabel optional>Required By</FieldLabel>
             <input
               type="date"
-              className={`${inputCls} ${mono.className}`}
+              className={`field-input-alt ${mono.className}`}
               {...register('requiredByDate')}
             />
           </div>
@@ -190,7 +188,7 @@ export default function NewQuotePage() {
                 type="number"
                 min={0}
                 placeholder="0.00"
-                className={`${inputCls} ${mono.className}`}
+                className={`field-input-alt ${mono.className}`}
                 {...register('budgetMin', { valueAsNumber: true })}
               />
             </div>
@@ -200,7 +198,7 @@ export default function NewQuotePage() {
                 type="number"
                 min={0}
                 placeholder="0.00"
-                className={`${inputCls} ${mono.className}`}
+                className={`field-input-alt ${mono.className}`}
                 {...register('budgetMax', { valueAsNumber: true })}
               />
             </div>
@@ -214,7 +212,7 @@ export default function NewQuotePage() {
             <textarea
               rows={3}
               placeholder="Any specific technical requirements..."
-              className={`${textareaCls} ${mono.className}`}
+              className={`field-textarea-alt ${mono.className}`}
               {...register('specialRequirements')}
             />
           </div>
@@ -223,7 +221,7 @@ export default function NewQuotePage() {
             <textarea
               rows={2}
               placeholder="Anything else you'd like us to know..."
-              className={`${textareaCls} ${mono.className}`}
+              className={`field-textarea-alt ${mono.className}`}
               {...register('notes')}
             />
           </div>

--- a/src/web/app/(public)/home/page.tsx
+++ b/src/web/app/(public)/home/page.tsx
@@ -7,6 +7,7 @@ import { useQuery } from '@tanstack/react-query';
 import { ArrowRight, X } from 'lucide-react';
 import { materialsApi, type Material } from '@/lib/api/materials';
 import { contentApi, type PortfolioItemResponse } from '@/lib/api/content';
+import { groupMaterials, type MaterialGroup } from '@/lib/utils';
 
 // ─── Fonts ────────────────────────────────────────────────────────────────────
 
@@ -69,28 +70,6 @@ const PROCESS_STEPS = [
     desc: 'Every print is inspected before it ships. We offer shipping across Northern Colorado and local pickup in Fort Collins.',
   },
 ];
-
-// ─── Material type grouping ───────────────────────────────────────────────────
-type MaterialGroup = {
-  type:     string;
-  variants: Material[];
-  minPrice: number;
-  maxPrice: number;
-};
-
-function groupMaterials(materials: Material[]): MaterialGroup[] {
-  const map = new Map<string, Material[]>();
-  for (const m of materials) {
-    const existing = map.get(m.type) ?? [];
-    map.set(m.type, [...existing, m]);
-  }
-  return Array.from(map.entries()).map(([type, variants]) => ({
-    type,
-    variants,
-    minPrice: Math.min(...variants.map(v => v.pricePerGram)),
-    maxPrice: Math.max(...variants.map(v => v.pricePerGram)),
-  }));
-}
 
 // ─── Material type tile ───────────────────────────────────────────────────────
 function MaterialTile({

--- a/src/web/app/(public)/pricing/page.tsx
+++ b/src/web/app/(public)/pricing/page.tsx
@@ -6,27 +6,8 @@ import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { ArrowRight, ChevronDown, ChevronUp } from 'lucide-react';
 import { materialsApi, type Material } from '@/lib/api/materials';
+import { groupMaterials, type MaterialGroup } from '@/lib/utils';
 
-
-type MaterialGroup = {
-  type:     string;
-  variants: Material[];
-  minPrice: number;
-  maxPrice: number;
-};
-
-function groupMaterials(materials: Material[]): MaterialGroup[] {
-  const map = new Map<string, Material[]>();
-  for (const m of materials) {
-    map.set(m.type, [...(map.get(m.type) ?? []), m]);
-  }
-  return Array.from(map.entries()).map(([type, variants]) => ({
-    type,
-    variants,
-    minPrice: Math.min(...variants.map(v => v.pricePerGram)),
-    maxPrice: Math.max(...variants.map(v => v.pricePerGram)),
-  }));
-}
 
 const QUALITY_TIERS = [
   { name: 'Draft',      layer: '0.3mm',  multiplier: '×0.8', desc: 'Fast. Functional. Good for form-fit tests.',        highlight: false },

--- a/src/web/app/globals.css
+++ b/src/web/app/globals.css
@@ -134,6 +134,20 @@
            placeholder:text-text-muted focus:outline-none focus:border-accent transition-colors resize-y;
   }
 
+  /* Field label — mono uppercase label above any form field */
+  .field-label {
+    @apply block text-[9px] uppercase tracking-[0.15em] text-text-muted mb-1.5;
+  }
+  /* surface-alt variants — used in dashboard forms (bg is slightly off-white) */
+  .field-input-alt {
+    @apply w-full h-9 bg-surface-alt border border-border px-3 text-[11px] text-text-primary
+           placeholder:text-text-muted focus:outline-none focus:border-accent transition-colors;
+  }
+  .field-textarea-alt {
+    @apply w-full bg-surface-alt border border-border px-3 py-2.5 text-[11px] text-text-primary
+           placeholder:text-text-muted focus:outline-none focus:border-accent transition-colors resize-none;
+  }
+
   /* Primary action button */
   .btn-primary {
     @apply bg-accent text-white text-[10px] uppercase tracking-[0.15em] font-medium

--- a/src/web/lib/utils.ts
+++ b/src/web/lib/utils.ts
@@ -1,5 +1,6 @@
 import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
+import type { Material } from "@/lib/api/materials";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
@@ -13,4 +14,25 @@ export function toProxiedUrl(url: string): string {
 /** "InReview" → "In Review", "QuoteProvided" → "Quote Provided" */
 export function formatStatus(s: string): string {
   return s.replace(/([A-Z])/g, ' $1').trim();
+}
+
+/** Groups a flat material list by type, computing per-group min/max price. */
+export type MaterialGroup = {
+  type:     string;
+  variants: Material[];
+  minPrice: number;
+  maxPrice: number;
+};
+
+export function groupMaterials(materials: Material[]): MaterialGroup[] {
+  const map = new Map<string, Material[]>();
+  for (const m of materials) {
+    map.set(m.type, [...(map.get(m.type) ?? []), m]);
+  }
+  return Array.from(map.entries()).map(([type, variants]) => ({
+    type,
+    variants,
+    minPrice: Math.min(...variants.map(v => v.pricePerGram)),
+    maxPrice: Math.max(...variants.map(v => v.pricePerGram)),
+  }));
 }


### PR DESCRIPTION
## What changed
Two separate copy-paste patterns consolidated. `groupMaterials` and its `MaterialGroup` type were defined identically in both `home/page.tsx` and `pricing/page.tsx` — both now import from `lib/utils.ts`. The dashboard form pages (`quotes/new`, `orders/new`, `profile`) each defined identical `inputCls`/`textareaCls` string constants locally — these are replaced with new `field-input-alt` and `field-textarea-alt` CSS utilities in `globals.css`, consistent with the existing `field-input`/`field-select`/`field-textarea` utilities already there. A `field-label` utility is also added to codify the repeated mono uppercase label pattern. No visual or behavioural changes.

## Related issue
Closes #30

## Type of change
- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [x] `chore` — refactor, deps, tooling (no behaviour change)
- [ ] `docs` — documentation only

## How to test
1. `npm run build` — should complete with no errors
2. Visual check: `/home`, `/pricing`, `/orders/new`, `/quotes/new`, `/profile` — all forms and material grids should look and behave identically to before

## Checklist
- [ ] CI passes (build, lint, tests)
- [x] No hardcoded secrets or credentials
- [x] New environment variables documented in `appsettings.json` / `.env.example`
- [x] Database migrations included if schema changed