### PR TITLE
feat: chunked file uploads for large 3D model files

### DIFF
--- a/src/api/PrintHub.API/Controllers/FilesController.cs
+++ b/src/api/PrintHub.API/Controllers/FilesController.cs
@@ -171,6 +171,94 @@ public class FilesController : ControllerBase
         return Ok(new { url });
     }
 
+    // ─── Chunked upload ───────────────────────────────────────────────────
+
+    /// <summary>
+    /// Initiate a chunked upload session.
+    /// Returns a blobName to use for all subsequent block uploads.
+    /// </summary>
+    [HttpPost("upload/initiate")]
+    public ActionResult<InitiateUploadResponse> InitiateUpload([FromBody] InitiateUploadRequest request)
+    {
+        var allowedExtensions = new[] { ".stl", ".obj", ".3mf", ".step", ".iges", ".gcode", ".amf", ".ply" };
+        var ext = Path.GetExtension(request.FileName).ToLower();
+        if (!allowedExtensions.Contains(ext))
+            return BadRequest(new { message = $"File type '{ext}' is not supported." });
+
+        var blobName = $"uploads/{Guid.NewGuid()}_{request.FileName}";
+        return Ok(new InitiateUploadResponse(blobName));
+    }
+
+    /// <summary>
+    /// Upload a single block as part of a chunked upload.
+    /// blockId must be a base64-encoded string of equal length across all blocks.
+    /// </summary>
+    [HttpPut("upload/block")]
+    [RequestSizeLimit(6_291_456)]                              // 6MB — slightly over 4MB chunk + headers
+    [RequestFormLimits(MultipartBodyLengthLimit = 6_291_456)]
+    public async Task<IActionResult> UploadBlock(
+        [FromQuery] string blobName,
+        [FromQuery] string blockId,
+        IFormFile block)
+    {
+        if (string.IsNullOrWhiteSpace(blobName) || string.IsNullOrWhiteSpace(blockId))
+            return BadRequest(new { message = "blobName and blockId are required." });
+
+        if (block == null || block.Length == 0)
+            return BadRequest(new { message = "No block data provided." });
+
+        await _storageService.StageBlockAsync(blobName, blockId, block.OpenReadStream());
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Commit all staged blocks, create the file record, and run analysis.
+    /// </summary>
+    [HttpPost("upload/complete")]
+    public async Task<ActionResult<FileResponse>> CompleteUpload(
+        [FromBody] CompleteUploadRequest request)
+    {
+        var userId = User.GetUserId();
+
+        var allowedExtensions = new[] { ".stl", ".obj", ".3mf", ".step", ".iges", ".gcode", ".amf", ".ply" };
+        var ext = Path.GetExtension(request.FileName).ToLower();
+        if (!allowedExtensions.Contains(ext))
+            return BadRequest(new { message = $"File type '{ext}' is not supported." });
+
+        var fileType = ext.TrimStart('.').ToUpper();
+        if (fileType == "3MF") fileType = "ThreeMF";
+
+        try
+        {
+            var fileUploadRequest = new FileUploadRequest(
+                OriginalFileName: request.FileName,
+                ContentType:      request.ContentType,
+                FileSizeBytes:    request.FileSizeBytes,
+                FileType:         fileType,
+                FileStream:       Stream.Null, // not used for chunked path
+                BlobName:         request.BlobName,
+                BlockIds:         request.BlockIds);
+
+            var response = await _fileService.CompleteChunkedUploadAsync(userId, fileUploadRequest);
+            return CreatedAtAction(nameof(GetFile), new { id = response.Id }, response);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { message = ex.Message });
+        }
+    }
+
     // ─── Private helpers ──────────────────────────────────────────────────
 
 }
+
+// ─── Request / response records ───────────────────────────────────────────────
+
+public record InitiateUploadRequest(string FileName);
+public record InitiateUploadResponse(string BlobName);
+public record CompleteUploadRequest(
+    string BlobName,
+    string FileName,
+    string ContentType,
+    long   FileSizeBytes,
+    IReadOnlyList<string> BlockIds);

--- a/src/api/PrintHub.API/Services/FileService.cs
+++ b/src/api/PrintHub.API/Services/FileService.cs
@@ -109,6 +109,88 @@ public class FileService : IFileService
         return FileResponse.FromEntity(file);
     }
 
+    public async Task<FileResponse> CompleteChunkedUploadAsync(Guid userId, FileUploadRequest request)
+    {
+        if (string.IsNullOrEmpty(request.BlobName) || request.BlockIds == null || request.BlockIds.Count == 0)
+            throw new InvalidOperationException("BlobName and BlockIds are required for chunked uploads.");
+
+        if (!Enum.TryParse<FileType>(request.FileType, ignoreCase: true, out var fileType))
+            throw new BusinessRuleException($"Unsupported file type: {request.FileType}");
+
+        // Commit all staged blocks into the final blob
+        var storageUrl = await _storageService.CommitBlocksAsync(
+            request.BlobName, request.BlockIds, request.ContentType);
+
+        var file = new UploadedFile
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            OriginalFileName = request.OriginalFileName,
+            StorageUrl = storageUrl,
+            BlobName = request.BlobName,
+            FileType = fileType,
+            FileSizeBytes = request.FileSizeBytes,
+            ContentType = request.ContentType,
+            IsAnalyzed = false,
+            UploadedAt = DateTime.UtcNow
+        };
+
+        await _fileRepo.AddAsync(file);
+        await _unitOfWork.SaveChangesAsync();
+
+        _logger.LogInformation(
+            "Chunked upload committed: {FileName} ({FileSize} bytes, {BlockCount} blocks) by user {UserId}",
+            request.OriginalFileName, request.FileSizeBytes, request.BlockIds.Count, userId);
+
+        // Run analysis if STL
+        if (fileType == FileType.STL)
+        {
+            try
+            {
+                using var stream = await _storageService.DownloadFileAsync(request.BlobName);
+                var analysis = await _analyzerService.AnalyzeAsync(stream, request.OriginalFileName);
+
+                if (analysis != null)
+                {
+                    var fileAnalysis = new FileAnalysis
+                    {
+                        Id = Guid.NewGuid(),
+                        FileId = file.Id,
+                        VolumeInCubicMm = analysis.VolumeInCubicMm,
+                        SurfaceArea = analysis.SurfaceArea,
+                        DimensionX = analysis.DimensionX,
+                        DimensionY = analysis.DimensionY,
+                        DimensionZ = analysis.DimensionZ,
+                        TriangleCount = analysis.TriangleCount,
+                        VertexCount = analysis.VertexCount,
+                        IsManifold = analysis.IsManifold,
+                        RequiresSupport = analysis.RequiresSupport,
+                        EstimatedWeightGrams = analysis.EstimatedWeightGrams,
+                        EstimatedPrintTimeHours = analysis.EstimatedPrintTimeHours,
+                        ComplexityScore = analysis.ComplexityScore,
+                        Warnings = System.Text.Json.JsonSerializer.Serialize(analysis.Warnings),
+                        AnalyzedAt = DateTime.UtcNow
+                    };
+
+                    await _analysisRepo.AddAsync(fileAnalysis);
+
+                    file.IsAnalyzed = true;
+                    _fileRepo.Update(file);
+                    await _unitOfWork.SaveChangesAsync();
+                }
+            }
+            catch (Exception ex)
+            {
+                // Analysis failure should not fail the upload
+                _logger.LogWarning(ex,
+                    "STL analysis failed for chunked upload {FileName} — file was saved successfully",
+                    request.OriginalFileName);
+            }
+        }
+
+        return FileResponse.FromEntity(file);
+    }
+
     public async Task<FileResponse?> GetFileByIdAsync(Guid fileId)
     {
         var file = await _fileRepo.GetFileWithAnalysisAsync(fileId);

--- a/src/api/PrintHub.Core/DTOs/Files/FileUploadRequest.cs
+++ b/src/api/PrintHub.Core/DTOs/Files/FileUploadRequest.cs
@@ -4,10 +4,13 @@ namespace PrintHub.Core.DTOs.Files;
 /// Metadata for a file upload.
 /// The actual file stream is handled separately by the controller
 /// since multipart form data doesn't map cleanly to a JSON DTO.
+/// For chunked uploads, FileStream is unused — BlobName and BlockIds are used instead.
 /// </summary>
 public record FileUploadRequest(
     string OriginalFileName,
     string ContentType,
     long FileSizeBytes,
     string FileType,
-    Stream FileStream);
+    Stream FileStream,
+    string? BlobName = null,
+    IReadOnlyList<string>? BlockIds = null);

--- a/src/api/PrintHub.Core/Interfaces/Services/IFileService.cs
+++ b/src/api/PrintHub.Core/Interfaces/Services/IFileService.cs
@@ -10,6 +10,7 @@ namespace PrintHub.Core.Interfaces.Services;
 public interface IFileService
 {
     Task<FileResponse> UploadFileAsync(Guid userId, FileUploadRequest request);
+    Task<FileResponse> CompleteChunkedUploadAsync(Guid userId, FileUploadRequest request);
     Task<FileResponse?> GetFileByIdAsync(Guid fileId);
     Task<FileResponse> ClonePortfolioFileAsync(Guid portfolioItemId, Guid userId);
     Task<PagedResponse<FileResponse>> GetUserFilesAsync(

--- a/src/api/PrintHub.Core/Interfaces/Services/IFileStorageService.cs
+++ b/src/api/PrintHub.Core/Interfaces/Services/IFileStorageService.cs
@@ -6,4 +6,15 @@ public interface IFileStorageService
     Task DeleteFileAsync(string blobName);
     Task<Stream> DownloadFileAsync(string blobName);
     Task<bool> ExistsAsync(string blobName);
+
+    /// <summary>
+    /// Stage a single block as part of a chunked upload.
+    /// The block remains uncommitted until CommitBlocksAsync is called.
+    /// </summary>
+    Task StageBlockAsync(string blobName, string blockId, Stream blockData);
+
+    /// <summary>
+    /// Commit all staged blocks into a single blob and set the content type.
+    /// </summary>
+    Task<string> CommitBlocksAsync(string blobName, IReadOnlyList<string> blockIds, string contentType);
 }

--- a/src/api/PrintHub.Infrastructure/Services/BlobStorageService.cs
+++ b/src/api/PrintHub.Infrastructure/Services/BlobStorageService.cs
@@ -1,5 +1,6 @@
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
+using Azure.Storage.Blobs.Specialized;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using PrintHub.Core.Interfaces.Services;
@@ -72,5 +73,27 @@ public class BlobStorageService : IFileStorageService
         var blobClient = _containerClient.GetBlobClient(blobName);
         var response = await blobClient.ExistsAsync();
         return response.Value;
+    }
+
+    public async Task StageBlockAsync(string blobName, string blockId, Stream blockData)
+    {
+        var blobClient = _containerClient.GetBlockBlobClient(blobName);
+        await blobClient.StageBlockAsync(blockId, blockData);
+        _logger.LogDebug("Staged block {BlockId} for blob {BlobName}", blockId, blobName);
+    }
+
+    public async Task<string> CommitBlocksAsync(
+        string blobName, IReadOnlyList<string> blockIds, string contentType)
+    {
+        var blobClient = _containerClient.GetBlockBlobClient(blobName);
+        await blobClient.CommitBlockListAsync(blockIds, new BlobHttpHeaders
+        {
+            ContentType = contentType,
+        });
+
+        _logger.LogInformation(
+            "Committed {BlockCount} blocks for blob {BlobName}", blockIds.Count, blobName);
+
+        return blobClient.Uri.ToString();
     }
 }

--- a/src/web/app/(dashboard)/upload/file-dropzone.tsx
+++ b/src/web/app/(dashboard)/upload/file-dropzone.tsx
@@ -11,9 +11,10 @@ const MAX_SIZE_MB = 250;
 interface FileDropzoneProps {
   onFileSelect: (file: File) => void;
   isUploading:  boolean;
+  uploadProgress?: number; // 0–100
 }
 
-export function FileDropzone({ onFileSelect, isUploading }: FileDropzoneProps) {
+export function FileDropzone({ onFileSelect, isUploading, uploadProgress = 0 }: FileDropzoneProps) {
   const [dragOver,     setDragOver]     = useState(false);
   const [error,        setError]        = useState<string | null>(null);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
@@ -79,12 +80,25 @@ export function FileDropzone({ onFileSelect, isUploading }: FileDropzoneProps) {
 
         {isUploading && (
           <div className="px-4 pb-3">
+            {/* Real progress bar */}
             <div className="h-[2px] w-full bg-border overflow-hidden">
-              <div className="h-full bg-accent/60 animate-pulse w-3/4 transition-all" />
+              <div
+                className="h-full bg-accent transition-all duration-300 ease-out"
+                style={{ width: `${uploadProgress}%` }}
+              />
             </div>
-            <p className={`${mono.className} text-[9px] text-accent/50 mt-1.5 animate-pulse`}>
-              Uploading...
-            </p>
+            <div className="flex items-center justify-between mt-1.5">
+              <p className={`${mono.className} text-[9px] text-accent/50`}>
+                {uploadProgress < 90
+                  ? `Uploading — ${uploadProgress}%`
+                  : uploadProgress < 100
+                  ? 'Committing...'
+                  : 'Analysing...'}
+              </p>
+              <p className={`${mono.className} text-[9px] text-text-muted`}>
+                {uploadProgress}%
+              </p>
+            </div>
           </div>
         )}
       </div>

--- a/src/web/app/(dashboard)/upload/page.tsx
+++ b/src/web/app/(dashboard)/upload/page.tsx
@@ -15,13 +15,15 @@ import { FileText, ShoppingCart } from 'lucide-react';
 export default function UploadPage() {
   const router = useRouter();
   const { isAuthenticated, isInitialized } = useRequireAuth();
-  const [isUploading,  setIsUploading]  = useState(false);
-  const [uploadedFile, setUploadedFile] = useState<UploadedFile | null>(null);
-  const [uploadError,  setUploadError]  = useState<string | null>(null);
-  const [previewUrl,   setPreviewUrl]   = useState<string | null>(null);
+  const [isUploading,      setIsUploading]      = useState(false);
+  const [uploadProgress,   setUploadProgress]   = useState(0);
+  const [uploadedFile,     setUploadedFile]     = useState<UploadedFile | null>(null);
+  const [uploadError,      setUploadError]      = useState<string | null>(null);
+  const [previewUrl,       setPreviewUrl]       = useState<string | null>(null);
 
   const handleFileSelect = async (file: File) => {
     setIsUploading(true);
+    setUploadProgress(0);
     setUploadError(null);
     setUploadedFile(null);
 
@@ -33,12 +35,13 @@ export default function UploadPage() {
     }
 
     try {
-      const response = await filesApi.upload(file);
-      setUploadedFile(response.data);
+      const uploadedFile = await filesApi.uploadChunked(file, setUploadProgress);
+      setUploadedFile(uploadedFile);
     } catch {
       setUploadError('Upload failed — please try again.');
     } finally {
       setIsUploading(false);
+      setUploadProgress(0);
     }
   };
 
@@ -71,7 +74,7 @@ export default function UploadPage() {
       <div className="space-y-4">
 
         {/* ── Drop zone ── */}
-        <FileDropzone onFileSelect={handleFileSelect} isUploading={isUploading} />
+        <FileDropzone onFileSelect={handleFileSelect} isUploading={isUploading} uploadProgress={uploadProgress} />
 
         {uploadError && (
           <p className={`${mono.className} text-[10px] text-red-400`}>{uploadError}</p>

--- a/src/web/lib/api/files.ts
+++ b/src/web/lib/api/files.ts
@@ -26,13 +26,70 @@ export interface UploadedFile {
   analysis: FileAnalysis | null;
 }
 
+const CHUNK_SIZE = 4 * 1024 * 1024; // 4MB
+
+/** Encode a block index as a base64 block ID (Azure requirement: all IDs same length). */
+function blockId(index: number): string {
+  return btoa(String(index).padStart(8, '0'));
+}
+
 export const filesApi = {
+  /** Legacy single-request upload — kept for small files and internal use. */
   upload: (file: File) => {
     const formData = new FormData();
     formData.append('file', file);
     return apiClient.post<UploadedFile>('/Files/upload', formData, {
       headers: { 'Content-Type': 'multipart/form-data' },
     });
+  },
+
+  /**
+   * Chunked upload — splits the file into 4MB blocks, uploads each block,
+   * then commits. Calls onProgress(0–100) as blocks are uploaded.
+   */
+  uploadChunked: async (
+    file: File,
+    onProgress?: (pct: number) => void,
+  ): Promise<UploadedFile> => {
+    // 1. Initiate — get a blobName
+    const { data: { blobName } } = await apiClient.post<{ blobName: string }>(
+      '/Files/upload/initiate',
+      { fileName: file.name },
+    );
+
+    // 2. Upload blocks
+    const totalChunks = Math.ceil(file.size / CHUNK_SIZE);
+    const blockIds: string[] = [];
+
+    for (let i = 0; i < totalChunks; i++) {
+      const start  = i * CHUNK_SIZE;
+      const end    = Math.min(start + CHUNK_SIZE, file.size);
+      const chunk  = file.slice(start, end);
+      const id     = blockId(i);
+
+      const formData = new FormData();
+      formData.append('block', chunk, file.name);
+
+      await apiClient.put('/Files/upload/block', formData, {
+        params:  { blobName, blockId: id },
+        headers: { 'Content-Type': 'multipart/form-data' },
+      });
+
+      blockIds.push(id);
+      onProgress?.(Math.round(((i + 1) / totalChunks) * 90)); // 0–90% during upload
+    }
+
+    // 3. Commit
+    const { data } = await apiClient.post<UploadedFile>('/Files/upload/complete', {
+      blobName,
+      fileName:     file.name,
+      contentType:  file.type || 'application/octet-stream',
+      fileSizeBytes: file.size,
+      blockIds,
+    });
+
+    onProgress?.(100);
+    return data;
   },
 
   getMine: (page = 1, pageSize = 20) =>


### PR DESCRIPTION
## What changed
Replaces the single-request multipart upload with Azure Block Blob chunked uploads, enabling reliable transfers of large STL files without hitting request size or timeout limits. The file is split into 4MB blocks client-side, each block is staged individually, then a commit call assembles them into the final blob. A real progress bar replaces the indeterminate pulse animation, showing percentage and phase (Uploading, Committing, Analysing).

**Backend — three new endpoints:**
- `POST /Files/upload/initiate` — validates extension, returns a `blobName`
- `PUT /Files/upload/block?blobName=&blockId=` — stages a single block (6MB limit)
- `POST /Files/upload/complete` — commits all blocks, creates the DB record, runs STL analysis

**Infrastructure:** `BlobStorageService` gains `StageBlockAsync` and `CommitBlocksAsync` using `BlockBlobClient` from `Azure.Storage.Blobs.Specialized`.

**Frontend:** `filesApi.uploadChunked()` handles the full three-step flow with an `onProgress(0–100)` callback. Progress maps 0–90% to block uploads and 90–100% to the commit/analyse phase.

The original `POST /Files/upload` endpoint is unchanged — used for images, videos, and any future direct-upload use cases.

## Related issue
Closes #49

## Type of change
- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `chore` — refactor, deps, tooling (no behaviour change)
- [ ] `docs` — documentation only

## How to test
1. Upload a small STL (< 4MB) — completes in a single block, progress bar reaches 100%
2. Upload a large STL (> 4MB) — observe multiple block requests in DevTools Network tab, progress increments per block
3. Upload a non-STL file — verify it uploads successfully (no analysis attempted)
4. Corrupt or cancel mid-upload — verify the error state is shown and retry works
5. `dotnet test src/api/PrintHub.Tests` — 78 passed, 0 failed

## Checklist
- [ ] CI passes (build, lint, tests)
- [x] No hardcoded secrets or credentials
- [x] New environment variables documented in `appsettings.json` / `.env.example`
- [x] Database migrations included if schema changed