### PR TITLE
GH-40 - feat: Implement intake queue listing with filtering and pagination

### DIFF
--- a/src/api/PrintHub.API/Controllers/MaterialIntakeController.cs
+++ b/src/api/PrintHub.API/Controllers/MaterialIntakeController.cs
@@ -3,6 +3,7 @@ using ImageMagick;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using PrintHub.API.Extensions;
+using PrintHub.Core.DTOs.Common;
 using PrintHub.Core.DTOs.Intake;
 using PrintHub.Core.Entities;
 using PrintHub.Core.Interfaces.Services;
@@ -175,6 +176,18 @@ public class MaterialIntakeController : ControllerBase
                 correlationId
             });
         }
+    }
+
+    /// <summary>
+    /// Returns a filtered, paginated list of intake records.
+    /// Supports filtering by status, uploader, date range, and free-text search.
+    /// </summary>
+    [HttpGet]
+    public async Task<ActionResult<PagedResponse<MaterialIntakeResponse>>> GetIntakeQueue(
+        [FromQuery] IntakeQueueFilter filter)
+    {
+        var result = await _materialIntakeService.GetIntakeQueueAsync(filter);
+        return Ok(result);
     }
 
     [HttpGet("{intakeId:guid}")]

--- a/src/api/PrintHub.API/Services/MaterialIntakeService.cs
+++ b/src/api/PrintHub.API/Services/MaterialIntakeService.cs
@@ -1,7 +1,8 @@
 using System.Text.Json;
+using PrintHub.Core.Common;
+using PrintHub.Core.DTOs.Common;
 using PrintHub.Core.DTOs.Intake;
 using PrintHub.Core.Entities;
-using PrintHub.Core.Common;
 using PrintHub.Core.Exceptions;
 using PrintHub.Core.Interfaces;
 using PrintHub.Core.Interfaces.Services;
@@ -72,9 +73,10 @@ public class MaterialIntakeService : IMaterialIntakeService
         return intake is null ? null : MapToResponse(intake);
     }
 
-    public Task<IReadOnlyList<MaterialIntakeResponse>> GetIntakeQueueAsync(IntakeQueueFilter filter)
+    public async Task<PagedResponse<MaterialIntakeResponse>> GetIntakeQueueAsync(IntakeQueueFilter filter)
     {
-        throw new NotImplementedException("Queue filtering is implemented in issue #16.");
+        var pagedResult = await _intakeRepository.GetPagedAsync(filter);
+        return PagedResponse<MaterialIntakeResponse>.FromPagedResult(pagedResult, MapToResponse);
     }
 
     public async Task<IReadOnlyList<IntakeEventResponse>> GetIntakeEventsAsync(Guid intakeId)

--- a/src/api/PrintHub.Core/Interfaces/IMaterialIntakeRepository.cs
+++ b/src/api/PrintHub.Core/Interfaces/IMaterialIntakeRepository.cs
@@ -1,3 +1,5 @@
+using PrintHub.Core.Common;
+using PrintHub.Core.DTOs.Intake;
 using PrintHub.Core.Entities;
 
 namespace PrintHub.Core.Interfaces
@@ -20,5 +22,10 @@ namespace PrintHub.Core.Interfaces
         Task<IReadOnlyList<MaterialIntake>> GetRejectedOlderThanAsync(DateTime cutoffUtc);
 
         Task AddEventAsync(IntakeEvent intakeEvent);
+
+        /// <summary>
+        /// Returns a filtered, paginated page of intake records ordered by CreatedAtUtc descending.
+        /// </summary>
+        Task<PagedResult<MaterialIntake>> GetPagedAsync(IntakeQueueFilter filter);
     }
 }

--- a/src/api/PrintHub.Core/Interfaces/Services/IMaterialIntakeService.cs
+++ b/src/api/PrintHub.Core/Interfaces/Services/IMaterialIntakeService.cs
@@ -1,3 +1,4 @@
+using PrintHub.Core.DTOs.Common;
 using PrintHub.Core.DTOs.Intake;
 using PrintHub.Core.Entities;
 
@@ -17,7 +18,7 @@ namespace PrintHub.Core.Interfaces.Services
 
         Task<MaterialIntakeResponse?> GetIntakeAsync(Guid intakeId);
 
-        Task<IReadOnlyList<MaterialIntakeResponse>> GetIntakeQueueAsync(IntakeQueueFilter filter);
+        Task<PagedResponse<MaterialIntakeResponse>> GetIntakeQueueAsync(IntakeQueueFilter filter);
 
         Task<IReadOnlyList<IntakeEventResponse>> GetIntakeEventsAsync(Guid intakeId);
 

--- a/src/api/PrintHub.Infrastructure/Data/Repositories/MaterialIntakeRepository.cs
+++ b/src/api/PrintHub.Infrastructure/Data/Repositories/MaterialIntakeRepository.cs
@@ -1,4 +1,6 @@
 using Microsoft.EntityFrameworkCore;
+using PrintHub.Core.Common;
+using PrintHub.Core.DTOs.Intake;
 using PrintHub.Core.Entities;
 using PrintHub.Core.Interfaces;
 using PrintHub.Infrastructure.Data;
@@ -44,6 +46,43 @@ namespace PrintHub.Infrastructure.Data.Repositories
         public async Task AddEventAsync(IntakeEvent intakeEvent)
         {
             await _context.IntakeEvents.AddAsync(intakeEvent);
+        }
+
+        public async Task<PagedResult<MaterialIntake>> GetPagedAsync(IntakeQueueFilter filter)
+        {
+            var query = _context.MaterialIntakes.AsQueryable();
+
+            if (filter.Status.HasValue)
+                query = query.Where(i => i.Status == filter.Status.Value);
+
+            if (filter.UploadedByUserId.HasValue)
+                query = query.Where(i => i.UploadedByUserId == filter.UploadedByUserId.Value);
+
+            if (filter.CreatedAfterUtc.HasValue)
+                query = query.Where(i => i.CreatedAtUtc >= filter.CreatedAfterUtc.Value);
+
+            if (filter.CreatedBeforeUtc.HasValue)
+                query = query.Where(i => i.CreatedAtUtc <= filter.CreatedBeforeUtc.Value);
+
+            if (!string.IsNullOrWhiteSpace(filter.SearchText))
+            {
+                var search = filter.SearchText.ToLower();
+                query = query.Where(i =>
+                    (i.DraftBrand != null && i.DraftBrand.ToLower().Contains(search)) ||
+                    (i.DraftMaterialType != null && i.DraftMaterialType.ToLower().Contains(search)) ||
+                    (i.DraftColor != null && i.DraftColor.ToLower().Contains(search)) ||
+                    (i.UploadNotes != null && i.UploadNotes.ToLower().Contains(search)));
+            }
+
+            var totalCount = await query.CountAsync();
+
+            var items = await query
+                .OrderByDescending(i => i.CreatedAtUtc)
+                .Skip((filter.Page - 1) * filter.PageSize)
+                .Take(filter.PageSize)
+                .ToListAsync();
+
+            return new PagedResult<MaterialIntake>(items, totalCount, filter.Page, filter.PageSize);
         }
     }
 }

--- a/src/api/PrintHub.Tests/Services/MaterialIntakeServiceTests.cs
+++ b/src/api/PrintHub.Tests/Services/MaterialIntakeServiceTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using Moq;
 using PrintHub.API.Services;
 using PrintHub.Core.Common;
+using PrintHub.Core.DTOs.Common;
 using PrintHub.Core.DTOs.Intake;
 using PrintHub.Core.Entities;
 using PrintHub.Core.Exceptions;
@@ -278,5 +279,74 @@ public class MaterialIntakeServiceTests
         var act = async () => await _sut.RejectIntakeAsync(
             Guid.NewGuid(), new RejectIntakeRequest("Some reason."), Guid.NewGuid());
         await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    // ── GetIntakeQueueAsync ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetIntakeQueue_NoFilters_ReturnsAllItems()
+    {
+        // Arrange
+        var intakes = new List<MaterialIntake>
+        {
+            TestDataBuilder.CreateMaterialIntake(status: IntakeStatus.Uploaded),
+            TestDataBuilder.CreateMaterialIntake(status: IntakeStatus.NeedsReview),
+            TestDataBuilder.CreateMaterialIntake(status: IntakeStatus.Approved),
+        };
+        var filter = new IntakeQueueFilter();
+        var pagedResult = new PagedResult<MaterialIntake>(intakes, intakes.Count, 1, 25);
+
+        _intakeRepoMock.Setup(r => r.GetPagedAsync(filter)).ReturnsAsync(pagedResult);
+
+        // Act
+        var result = await _sut.GetIntakeQueueAsync(filter);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Items.Should().HaveCount(3);
+        result.TotalCount.Should().Be(3);
+        result.Page.Should().Be(1);
+        result.PageSize.Should().Be(25);
+        _intakeRepoMock.Verify(r => r.GetPagedAsync(filter), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetIntakeQueue_StatusFilter_ForwardsFilterToRepository()
+    {
+        // Arrange
+        var intake = TestDataBuilder.CreateMaterialIntake(status: IntakeStatus.NeedsReview);
+        var filter = new IntakeQueueFilter(Status: IntakeStatus.NeedsReview);
+        var pagedResult = new PagedResult<MaterialIntake>([intake], 1, 1, 25);
+
+        _intakeRepoMock.Setup(r => r.GetPagedAsync(filter)).ReturnsAsync(pagedResult);
+
+        // Act
+        var result = await _sut.GetIntakeQueueAsync(filter);
+
+        // Assert
+        result.Items.Should().HaveCount(1);
+        result.Items[0].Status.Should().Be(IntakeStatus.NeedsReview);
+        _intakeRepoMock.Verify(r => r.GetPagedAsync(It.Is<IntakeQueueFilter>(f =>
+            f.Status == IntakeStatus.NeedsReview)), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetIntakeQueue_EmptyResult_ReturnsPagesResponseWithZeroItems()
+    {
+        // Arrange
+        var filter = new IntakeQueueFilter(SearchText: "nonexistent-brand-xyz");
+        var pagedResult = new PagedResult<MaterialIntake>([], 0, 1, 25);
+
+        _intakeRepoMock.Setup(r => r.GetPagedAsync(filter)).ReturnsAsync(pagedResult);
+
+        // Act
+        var result = await _sut.GetIntakeQueueAsync(filter);
+
+        // Assert
+        result.Items.Should().BeEmpty();
+        result.TotalCount.Should().Be(0);
+        result.TotalPages.Should().Be(0);
+        result.HasNextPage.Should().BeFalse();
+        result.HasPreviousPage.Should().BeFalse();
     }
 }


### PR DESCRIPTION
## Overview
Implements the `GET /api/v1.0/material-intake` endpoint for Issue #40 — paginated, filtered listing of the material intake queue. The service stub that previously threw `NotImplementedException` is now fully wired end-to-end.

## Changes Made

### `PrintHub.Core/Interfaces/IMaterialIntakeRepository.cs`
- Added `Task<PagedResult<MaterialIntake>> GetPagedAsync(IntakeQueueFilter filter)` to the repository interface

### `PrintHub.Infrastructure/Data/Repositories/MaterialIntakeRepository.cs`
- Implemented `GetPagedAsync` with EF Core query supporting all five filter dimensions:
  - `Status` — exact match
  - `UploadedByUserId` — exact match
  - `CreatedAfterUtc` / `CreatedBeforeUtc` — inclusive date range
  - `SearchText` — case-insensitive substring match across `DraftBrand`, `DraftMaterialType`, `DraftColor`, and `UploadNotes`
- Orders results by `CreatedAtUtc DESC`, applies skip/take for paging

### `PrintHub.Core/Interfaces/Services/IMaterialIntakeService.cs`
- Changed `GetIntakeQueueAsync` return type from `IReadOnlyList<MaterialIntakeResponse>` to `PagedResponse<MaterialIntakeResponse>` — consistent with Orders, Quotes, Files, and Content endpoints

### `PrintHub.API/Services/MaterialIntakeService.cs`
- Implemented `GetIntakeQueueAsync` — calls `_intakeRepository.GetPagedAsync(filter)` then wraps in `PagedResponse<MaterialIntakeResponse>.FromPagedResult(result, MapToResponse)`

### `PrintHub.API/Controllers/MaterialIntakeController.cs`
- Added `GET /api/v1.0/material-intake` endpoint accepting `[FromQuery] IntakeQueueFilter`
- Returns `200 OK` with `PagedResponse<MaterialIntakeResponse>`

### `PrintHub.Tests/Services/MaterialIntakeServiceTests.cs`
- Added 3 new unit tests for `GetIntakeQueueAsync`:
  - `GetIntakeQueue_NoFilters_ReturnsAllItems`
  - `GetIntakeQueue_StatusFilter_ForwardsFilterToRepository`
  - `GetIntakeQueue_EmptyResult_ReturnsPagesResponseWithZeroItems`

## Breaking Changes
- `IMaterialIntakeService.GetIntakeQueueAsync` return type changed from `IReadOnlyList<>` to `PagedResponse<>`. Any callers outside this PR (none currently exist) must be updated.

## Testing
- `dotnet build PrintHub.slnx` → **0 errors, 0 warnings**
- `dotnet test PrintHub.slnx` → **81/81 passed** (3 new tests added)

## Related
- GitHub: GH-40
- Issue: #40 — API: Add intake draft retrieval and queue listing endpoints
- Epic: #44 — Material Photo Intake v1