### PR TITLE
infra: Provision Azure AI Computer Vision resource for material photo extraction

### DIFF
--- a/infrastructure/main.bicep
+++ b/infrastructure/main.bicep
@@ -51,6 +51,22 @@ module storage 'modules/storage.bicep' = {
   }
 }
 
+// ── Azure AI Computer Vision ───────────────────────────────────────────────────
+//
+// Provides the Image Analysis 4.0 endpoint and key consumed by
+// AzureVisionExtractionProvider in the material photo intake pipeline.
+// The storage queue used by AzureMaterialIntakeQueue is auto-created at
+// startup via CreateIfNotExists() — no separate queue resource needed here.
+
+module aiVision 'modules/ai-vision.bicep' = {
+  name: 'aiVision'
+  params: {
+    location: location
+    environmentName: environmentName
+    appName: appName
+  }
+}
+
 // ── PostgreSQL ────────────────────────────────────────────────────────────────
 
 module postgres 'modules/postgres.bicep' = {
@@ -88,6 +104,8 @@ module appService 'modules/appservice.bicep' = {
     stripeSecretKey: stripeSecretKey
     stripeWebhookSecret: stripeWebhookSecret
     webAppUrl: webUrl
+    aiVisionEndpoint: aiVision.outputs.endpoint
+    aiVisionKey: aiVision.outputs.key
   }
 }
 

--- a/infrastructure/modules/ai-vision.bicep
+++ b/infrastructure/modules/ai-vision.bicep
@@ -1,0 +1,50 @@
+@description('Azure region for all resources.')
+param location string
+
+@description('Short environment tag (dev | prod).')
+param environmentName string
+
+@description('Base name shared across all resources.')
+param appName string
+
+// ── Computer Vision resource ──────────────────────────────────────────────────
+//
+// Azure AI Vision 4.0 Image Analysis (api-version=2024-02-01) uses the
+// standard ComputerVision Cognitive Services endpoint:
+//   https://<name>.cognitiveservices.azure.com/
+//
+// Supported regions for Image Analysis 4.0: eastus, westus, westeurope,
+// westus2, eastasia, southeastasia, and others — confirm at:
+//   https://learn.microsoft.com/azure/ai-services/computer-vision/overview-image-analysis
+//
+// SKU options:
+//   F0 — Free tier: 5,000 transactions/month, 20 calls/minute (1 free per subscription/region)
+//   S1 — Pay-per-use: $1.00/1,000 transactions (use for prod if volume warrants it)
+//
+var visionResourceName = '${appName}-vision-${environmentName}'
+
+resource computerVision 'Microsoft.CognitiveServices/accounts@2023-05-01' = {
+  name: visionResourceName
+  location: location
+  kind: 'ComputerVision'
+  sku: {
+    name: environmentName == 'prod' ? 'S1' : 'F0'
+  }
+  properties: {
+    publicNetworkAccess: 'Enabled'
+    // Disabling local (key) auth would require managed identity wiring; keep enabled
+    // for the simple key-based flow the AzureVisionExtractionProvider uses.
+    disableLocalAuth: false
+  }
+  tags: {
+    environment: environmentName
+    project: appName
+  }
+}
+
+// ── Outputs ───────────────────────────────────────────────────────────────────
+
+output endpoint string = computerVision.properties.endpoint
+
+@secure()
+output key string = computerVision.listKeys().key1

--- a/infrastructure/modules/appservice.bicep
+++ b/infrastructure/modules/appservice.bicep
@@ -32,6 +32,11 @@ param stripeWebhookSecret string
 
 param webAppUrl string
 
+param aiVisionEndpoint string
+
+@secure()
+param aiVisionKey string
+
 resource appServicePlan 'Microsoft.Web/serverfarms@2023-12-01' = {
   name: 'plan-${appName}-${environmentName}'
   location: location
@@ -68,7 +73,10 @@ resource webApp 'Microsoft.Web/sites@2023-12-01' = {
         { name: 'Email__ResendApiKey',           value: resendApiKey }
         { name: 'Stripe__SecretKey',             value: stripeSecretKey }
         { name: 'Stripe__WebhookSecret',         value: stripeWebhookSecret }
-        { name: 'WebAppUrl',                     value: webAppUrl }
+        { name: 'WebAppUrl',                                       value: webAppUrl }
+        { name: 'Intake__Extractor__Provider',                     value: 'AzureVision' }
+        { name: 'Intake__Extractor__AzureVision__Endpoint',        value: aiVisionEndpoint }
+        { name: 'Intake__Extractor__AzureVision__Key',             value: aiVisionKey }
       ]
       connectionStrings: [
         {


### PR DESCRIPTION
## Summary
Adds the Azure AI Computer Vision Bicep resource required by `AzureVisionExtractionProvider` so the material photo intake pipeline runs in `AzureVision` mode in Azure rather than `Mock`.

## Changes
- `infrastructure/modules/ai-vision.bicep` — new module, `ComputerVision` kind, F0 dev / S1 prod
- `infrastructure/modules/appservice.bicep` — adds `aiVisionEndpoint`/`aiVisionKey` params + three new app settings
- `infrastructure/main.bicep` — invokes `aiVision` module, wires outputs to `appservice`

## Testing
- [ ] `az deployment group create --what-if` passes locally
- [ ] Deployed to dev resource group; Computer Vision resource visible in portal
- [ ] API app settings confirm `Intake__Extractor__Provider=AzureVision`
- [ ] Test upload processed through `AzureVisionExtractionProvider` (not Mock)

closes #82