### PR TITLE
fix: Serialize PrintSettingsHints string before writing to jsonb column

### DIFF
--- a/src/api/PrintHub.API/Services/Intake/IntakeExtractionProcessor.cs
+++ b/src/api/PrintHub.API/Services/Intake/IntakeExtractionProcessor.cs
@@ -107,7 +107,9 @@ public class IntakeExtractionProcessor
             intake.DraftMaterialType         = result.MaterialType;
             intake.DraftColor                = result.Color;
             intake.DraftSpoolWeightGrams     = result.SpoolWeightGrams;
-            intake.DraftPrintSettingsHints   = result.PrintSettingsHints;
+            intake.DraftPrintSettingsHints   = result.PrintSettingsHints is not null
+                ? JsonSerializer.Serialize(result.PrintSettingsHints)
+                : null;
             intake.DraftBatchOrLot           = result.BatchOrLot;
             intake.ConfidenceMap             = JsonSerializer.Serialize(
                 new Dictionary<string, object?>


### PR DESCRIPTION
## Problem
`DraftPrintSettingsHints` is a `jsonb` column. After #93, the extraction provider returns a plain string (e.g. `Speed: 30-50mm/s, Fan: OFF`) which PostgreSQL rejects with `22P02: invalid input syntax for type json`.

## Fix
Wrap the assignment in `JsonSerializer.Serialize()` before writing to the entity. Npgsql deserializes the stored JSON string back to a plain C# string on read, so the API and frontend are unaffected.

## Testing
- [ ] Upload a label photo — extraction completes without 22P02 error
- [ ] Print Settings field populates on the intake detail page