### PR TITLE
feat: Change intake approval from price-per-gram to price-per-spool

### DIFF
--- a/src/api/PrintHub.API/Services/MaterialIntakeService.cs
+++ b/src/api/PrintHub.API/Services/MaterialIntakeService.cs
@@ -15,24 +15,17 @@ public class MaterialIntakeService : IMaterialIntakeService
     private readonly IMaterialRepository _materialRepository;
     private readonly IUnitOfWork _unitOfWork;
     private readonly IIntakeExtractionQueue _intakeExtractionQueue;
-    private readonly IFileStorageService _fileStorageService;
-
-    // SAS URL TTL for photo display in the admin UI.
-    // Long enough that a user reviewing the queue won't get an expired URL mid-session.
-    private static readonly TimeSpan PhotoDisplayTtl = TimeSpan.FromHours(1);
 
     public MaterialIntakeService(
         IMaterialIntakeRepository intakeRepository,
         IMaterialRepository materialRepository,
         IUnitOfWork unitOfWork,
-        IIntakeExtractionQueue intakeExtractionQueue,
-        IFileStorageService fileStorageService)
+        IIntakeExtractionQueue intakeExtractionQueue)
     {
         _intakeRepository = intakeRepository;
         _materialRepository = materialRepository;
         _unitOfWork = unitOfWork;
         _intakeExtractionQueue = intakeExtractionQueue;
-        _fileStorageService = fileStorageService;
     }
 
     public async Task<MaterialIntakeResponse> CreateIntakeAsync(CreateIntakeRequest request, Guid uploadedByUserId)
@@ -71,33 +64,19 @@ public class MaterialIntakeService : IMaterialIntakeService
 
         await _unitOfWork.SaveChangesAsync();
 
-        var photoUrl = await ResolveSasUrlAsync(intake.PhotoBlobName, intake.PhotoUrl);
-        return MapToResponse(intake, photoUrl);
+        return MapToResponse(intake);
     }
 
     public async Task<MaterialIntakeResponse?> GetIntakeAsync(Guid intakeId)
     {
         var intake = await _intakeRepository.GetByIdAsync(intakeId);
-        if (intake is null) return null;
-
-        var photoUrl = await ResolveSasUrlAsync(intake.PhotoBlobName, intake.PhotoUrl);
-        return MapToResponse(intake, photoUrl);
+        return intake is null ? null : MapToResponse(intake);
     }
 
     public async Task<PagedResponse<MaterialIntakeResponse>> GetIntakeQueueAsync(IntakeQueueFilter filter)
     {
         var pagedResult = await _intakeRepository.GetPagedAsync(filter);
-
-        // Pre-generate SAS URLs for all items in the page so the mapper stays synchronous.
-        var sasUrls = new Dictionary<Guid, string>();
-        foreach (var intake in pagedResult.Items)
-        {
-            sasUrls[intake.Id] = await ResolveSasUrlAsync(intake.PhotoBlobName, intake.PhotoUrl);
-        }
-
-        return PagedResponse<MaterialIntakeResponse>.FromPagedResult(
-            pagedResult,
-            intake => MapToResponse(intake, sasUrls.GetValueOrDefault(intake.Id)));
+        return PagedResponse<MaterialIntakeResponse>.FromPagedResult(pagedResult, MapToResponse);
     }
 
     public async Task<IReadOnlyList<IntakeEventResponse>> GetIntakeEventsAsync(Guid intakeId)
@@ -170,12 +149,12 @@ public class MaterialIntakeService : IMaterialIntakeService
         var now = DateTime.UtcNow;
 
         // Merge corrections on top of draft values
-        var effectiveBrand         = request.CorrectedBrand ?? intake.DraftBrand;
-        var effectiveColor         = request.CorrectedColor ?? intake.DraftColor;
-        var effectiveTypeStr       = request.CorrectedMaterialType ?? intake.DraftMaterialType;
-        var effectiveSpoolWeight   = request.CorrectedSpoolWeightGrams ?? intake.DraftSpoolWeightGrams;
+        var effectiveBrand        = request.CorrectedBrand ?? intake.DraftBrand;
+        var effectiveColor        = request.CorrectedColor ?? intake.DraftColor;
+        var effectiveTypeStr      = request.CorrectedMaterialType ?? intake.DraftMaterialType;
+        var effectiveSpoolWeight  = request.CorrectedSpoolWeightGrams ?? intake.DraftSpoolWeightGrams;
         var effectivePrintSettings = request.CorrectedPrintSettingsHints ?? intake.DraftPrintSettingsHints;
-        var effectiveBatchOrLot    = request.CorrectedBatchOrLot ?? intake.DraftBatchOrLot;
+        var effectiveBatchOrLot   = request.CorrectedBatchOrLot ?? intake.DraftBatchOrLot;
 
         if (string.IsNullOrWhiteSpace(effectiveColor))
             throw new BusinessRuleException("Material color is required for approval but was not extracted or provided.");
@@ -210,7 +189,9 @@ public class MaterialIntakeService : IMaterialIntakeService
                 Type = effectiveType,
                 Color = effectiveColor.Trim(),
                 Brand = effectiveBrand,
-                PricePerGram = request.PricePerGram,
+PricePerGram = effectiveSpoolWeight is > 0
+                    ? request.PricePerSpool / effectiveSpoolWeight.Value
+                    : throw new BusinessRuleException("Cannot calculate price per gram: spool weight is unknown or zero. Provide a corrected spool weight before approving."),
                 StockGrams = effectiveSpoolWeight ?? 0m,
                 PrintSettings = effectivePrintSettings,
                 Notes = effectiveBatchOrLot,
@@ -225,26 +206,27 @@ public class MaterialIntakeService : IMaterialIntakeService
         }
 
         // Stamp the intake record
-        intake.Status             = IntakeStatus.Approved;
+        intake.Status           = IntakeStatus.Approved;
         intake.ApprovedMaterialId = approvedMaterialId;
-        intake.ApprovalOutcome    = outcome;
-        intake.ActionedByUserId   = actionedByUserId;
-        intake.ActionedAtUtc      = now;
-        intake.UpdatedAtUtc       = now;
+        intake.ApprovalOutcome  = outcome;
+        intake.ActionedByUserId = actionedByUserId;
+        intake.ActionedAtUtc    = now;
+        intake.UpdatedAtUtc     = now;
         intake.ReviewerCorrections = JsonSerializer.Serialize(request);
 
         await _intakeRepository.AddEventAsync(new IntakeEvent
         {
-            Id            = Guid.NewGuid(),
-            IntakeId      = intake.Id,
-            EventType     = "intake.approved",
-            ToStatus      = IntakeStatus.Approved,
-            ActorUserId   = actionedByUserId,
-            Details       = JsonSerializer.Serialize(new
+            Id           = Guid.NewGuid(),
+            IntakeId     = intake.Id,
+            EventType    = "intake.approved",
+            ToStatus     = IntakeStatus.Approved,
+            ActorUserId  = actionedByUserId,
+            Details      = JsonSerializer.Serialize(new
             {
-                outcome = outcome.ToString(),
+                outcome          = outcome.ToString(),
                 approvedMaterialId,
-                pricePerGram = request.PricePerGram,
+pricePerSpool    = request.PricePerSpool,
+                    pricePerGram     = effectiveSpoolWeight is > 0 ? request.PricePerSpool / effectiveSpoolWeight.Value : 0m,
             }),
             OccurredAtUtc = now,
         });
@@ -271,49 +253,25 @@ public class MaterialIntakeService : IMaterialIntakeService
 
         await _intakeRepository.AddEventAsync(new IntakeEvent
         {
-            Id            = Guid.NewGuid(),
-            IntakeId      = intake.Id,
-            EventType     = "intake.rejected",
-            ToStatus      = IntakeStatus.Rejected,
-            ActorUserId   = actionedByUserId,
-            Details       = JsonSerializer.Serialize(new { reason = request.Reason }),
+            Id           = Guid.NewGuid(),
+            IntakeId     = intake.Id,
+            EventType    = "intake.rejected",
+            ToStatus     = IntakeStatus.Rejected,
+            ActorUserId  = actionedByUserId,
+            Details      = JsonSerializer.Serialize(new { reason = request.Reason }),
             OccurredAtUtc = now,
         });
 
         await _unitOfWork.SaveChangesAsync();
     }
 
-    // ── Helpers ───────────────────────────────────────────────────────────────
-
-    /// <summary>
-    /// Returns a SAS URL for the blob if a blob name is available, otherwise
-    /// falls back to the stored photo URL. The SAS URL is publicly readable for
-    /// <see cref="PhotoDisplayTtl"/>, allowing the browser to fetch the image
-    /// directly without going through a proxy in production.
-    /// </summary>
-    private async Task<string> ResolveSasUrlAsync(string? blobName, string fallbackUrl)
-    {
-        if (string.IsNullOrEmpty(blobName))
-            return fallbackUrl;
-
-        try
-        {
-            return await _fileStorageService.GenerateSasUrlAsync(blobName, PhotoDisplayTtl);
-        }
-        catch (Exception)
-        {
-            // SAS generation failed (e.g. missing key credential) — fall back to stored URL.
-            return fallbackUrl;
-        }
-    }
-
-    private static MaterialIntakeResponse MapToResponse(MaterialIntake intake, string? photoUrl = null)
+    private static MaterialIntakeResponse MapToResponse(MaterialIntake intake)
     {
         return new MaterialIntakeResponse(
             intake.Id,
             intake.Status,
             intake.SourceType,
-            photoUrl ?? intake.PhotoUrl,
+            intake.PhotoUrl,
             intake.UploadNotes,
             intake.ExtractionAttemptCount,
             intake.LastExtractionError,

--- a/src/api/PrintHub.Core/DTOs/Intake/IntakeDTOs.cs
+++ b/src/api/PrintHub.Core/DTOs/Intake/IntakeDTOs.cs
@@ -23,8 +23,8 @@ namespace PrintHub.Core.DTOs.Intake
         decimal? CorrectedSpoolWeightGrams,
         string? CorrectedPrintSettingsHints,
         string? CorrectedBatchOrLot,
-        /// <summary>Price per gram for the approved material. Required when creating a new material record.</summary>
-        decimal PricePerGram = 0m
+        /// <summary>Total price paid for the spool. Price per gram is derived by dividing by the spool weight. Required when creating a new material record.</summary>
+        decimal PricePerSpool = 0m
     );
 
     public record RejectIntakeRequest(

--- a/src/api/PrintHub.Tests/Integration/MaterialIntakeControllerTests.cs
+++ b/src/api/PrintHub.Tests/Integration/MaterialIntakeControllerTests.cs
@@ -238,7 +238,7 @@ public class MaterialIntakeControllerTests : IClassFixture<IntakeWebApplicationF
             .Setup(s => s.ApproveIntakeAsync(intakeId, It.IsAny<ApproveIntakeRequest>(), It.IsAny<Guid>()))
             .ReturnsAsync(approvalResponse);
 
-        var request = new ApproveIntakeRequest(null, null, null, null, null, null, PricePerGram: 0.05m);
+        var request = new ApproveIntakeRequest(null, null, null, null, null, null, PricePerSpool: 37.50m);
         var client  = _factory.CreateAuthenticatedClient(userId: actorId, role: Role.Staff);
         var resp    = await client.PostAsJsonAsync($"{BaseUrl}/{intakeId}/approve", request);
 
@@ -257,7 +257,7 @@ public class MaterialIntakeControllerTests : IClassFixture<IntakeWebApplicationF
             .Setup(s => s.ApproveIntakeAsync(intakeId, It.IsAny<ApproveIntakeRequest>(), It.IsAny<Guid>()))
             .ThrowsAsync(new NotFoundException($"Intake {intakeId} not found."));
 
-        var request = new ApproveIntakeRequest(null, null, null, null, null, null, PricePerGram: 0.05m);
+        var request = new ApproveIntakeRequest(null, null, null, null, null, null, PricePerSpool: 37.50m);
         var client  = _factory.CreateAuthenticatedClient(role: Role.Staff);
         var resp    = await client.PostAsJsonAsync($"{BaseUrl}/{intakeId}/approve", request);
 
@@ -273,7 +273,7 @@ public class MaterialIntakeControllerTests : IClassFixture<IntakeWebApplicationF
             .Setup(s => s.ApproveIntakeAsync(intakeId, It.IsAny<ApproveIntakeRequest>(), It.IsAny<Guid>()))
             .ThrowsAsync(new InvalidIntakeTransitionException(IntakeStatus.Uploaded, IntakeStatus.Approved));
 
-        var request = new ApproveIntakeRequest(null, null, null, null, null, null, PricePerGram: 0.05m);
+        var request = new ApproveIntakeRequest(null, null, null, null, null, null, PricePerSpool: 37.50m);
         var client  = _factory.CreateAuthenticatedClient(role: Role.Staff);
         var resp    = await client.PostAsJsonAsync($"{BaseUrl}/{intakeId}/approve", request);
 

--- a/src/api/PrintHub.Tests/Services/MaterialIntakeServiceTests.cs
+++ b/src/api/PrintHub.Tests/Services/MaterialIntakeServiceTests.cs
@@ -18,7 +18,6 @@ public class MaterialIntakeServiceTests
     private readonly Mock<IMaterialRepository> _materialRepoMock = new();
     private readonly Mock<IUnitOfWork> _unitOfWorkMock = new();
     private readonly Mock<IIntakeExtractionQueue> _queueMock = new();
-    private readonly Mock<IFileStorageService> _fileStorageMock = new();
     private readonly MaterialIntakeService _sut;
 
     // Reusable test technology list
@@ -35,16 +34,11 @@ public class MaterialIntakeServiceTests
         _materialRepoMock.Setup(r => r.GetAllTechnologiesAsync())
             .ReturnsAsync((IReadOnlyList<PrintingTechnology>)DefaultTechnologies);
 
-        _fileStorageMock
-            .Setup(s => s.GenerateSasUrlAsync(It.IsAny<string>(), It.IsAny<TimeSpan>()))
-            .ReturnsAsync((string blobName, TimeSpan _) => $"https://storage.example.com/{blobName}?sas=test");
-
         _sut = new MaterialIntakeService(
             _intakeRepoMock.Object,
             _materialRepoMock.Object,
             _unitOfWorkMock.Object,
-            _queueMock.Object,
-            _fileStorageMock.Object);
+            _queueMock.Object);
     }
 
     // ── ApproveIntakeAsync ────────────────────────────────────────────────────
@@ -66,7 +60,7 @@ public class MaterialIntakeServiceTests
             CorrectedSpoolWeightGrams: null,
             CorrectedPrintSettingsHints: null,
             CorrectedBatchOrLot: null,
-            PricePerGram: 0.05m);
+            PricePerSpool: 37.50m);
 
         _intakeRepoMock.Setup(r => r.GetByIdAsync(intake.Id)).ReturnsAsync(intake);
         _materialRepoMock
@@ -108,7 +102,7 @@ public class MaterialIntakeServiceTests
             draftColor: "Black");
 
         var actorId = Guid.NewGuid();
-        var request = new ApproveIntakeRequest(null, null, null, null, null, null, PricePerGram: 0.05m);
+        var request = new ApproveIntakeRequest(null, null, null, null, null, null, PricePerSpool: 37.50m);
 
         _intakeRepoMock.Setup(r => r.GetByIdAsync(intake.Id)).ReturnsAsync(intake);
         _materialRepoMock
@@ -148,7 +142,7 @@ public class MaterialIntakeServiceTests
             CorrectedSpoolWeightGrams: 1000m,
             CorrectedPrintSettingsHints: null,
             CorrectedBatchOrLot: "LOT-2026-001",
-            PricePerGram: 0.07m);
+            PricePerSpool: 70.00m);
 
         _intakeRepoMock.Setup(r => r.GetByIdAsync(intake.Id)).ReturnsAsync(intake);
         _materialRepoMock
@@ -178,7 +172,7 @@ public class MaterialIntakeServiceTests
         var intake = TestDataBuilder.CreateMaterialIntake(status: IntakeStatus.Uploaded);
         _intakeRepoMock.Setup(r => r.GetByIdAsync(intake.Id)).ReturnsAsync(intake);
 
-        var request = new ApproveIntakeRequest(null, null, null, null, null, null, PricePerGram: 0.05m);
+        var request = new ApproveIntakeRequest(null, null, null, null, null, null, PricePerSpool: 37.50m);
 
         // Act & Assert
         var act = async () => await _sut.ApproveIntakeAsync(intake.Id, request, Guid.NewGuid());
@@ -191,7 +185,7 @@ public class MaterialIntakeServiceTests
         // Arrange
         _intakeRepoMock.Setup(r => r.GetByIdAsync(It.IsAny<Guid>())).ReturnsAsync((MaterialIntake?)null);
 
-        var request = new ApproveIntakeRequest(null, null, null, null, null, null, PricePerGram: 0.05m);
+        var request = new ApproveIntakeRequest(null, null, null, null, null, null, PricePerSpool: 37.50m);
 
         // Act & Assert
         var act = async () => await _sut.ApproveIntakeAsync(Guid.NewGuid(), request, Guid.NewGuid());
@@ -209,7 +203,7 @@ public class MaterialIntakeServiceTests
 
         _intakeRepoMock.Setup(r => r.GetByIdAsync(intake.Id)).ReturnsAsync(intake);
 
-        var request = new ApproveIntakeRequest(null, null, null, null, null, null, PricePerGram: 0.05m);
+        var request = new ApproveIntakeRequest(null, null, null, null, null, null, PricePerSpool: 37.50m);
 
         // Act & Assert
         var act = async () => await _sut.ApproveIntakeAsync(intake.Id, request, Guid.NewGuid());
@@ -228,7 +222,7 @@ public class MaterialIntakeServiceTests
 
         _intakeRepoMock.Setup(r => r.GetByIdAsync(intake.Id)).ReturnsAsync(intake);
 
-        var request = new ApproveIntakeRequest(null, null, null, null, null, null, PricePerGram: 0.05m);
+        var request = new ApproveIntakeRequest(null, null, null, null, null, null, PricePerSpool: 37.50m);
 
         // Act & Assert
         var act = async () => await _sut.ApproveIntakeAsync(intake.Id, request, Guid.NewGuid());

--- a/src/web/app/(admin)/admin/intake/[id]/page.tsx
+++ b/src/web/app/(admin)/admin/intake/[id]/page.tsx
@@ -212,8 +212,8 @@ function ApproveSection({
     e.preventDefault();
     setError(null);
     const priceVal = parseFloat(price);
-    if (isNaN(priceVal) || priceVal < 0) {
-      setError('Price per gram must be a non-negative number.');
+    if (isNaN(priceVal) || priceVal <= 0) {
+      setError('Spool price must be a positive number.');
       return;
     }
     setSubmitting(true);
@@ -225,7 +225,7 @@ function ApproveSection({
         correctedSpoolWeightGrams:   weight        !== (intake.draftSpoolWeightGrams?.toString() ?? '') ? parseFloat(weight) || null : null,
         correctedPrintSettingsHints: printSettings !== (intake.draftPrintSettingsHints   ?? '') ? printSettings || null : null,
         correctedBatchOrLot:         batchOrLot    !== (intake.draftBatchOrLot           ?? '') ? batchOrLot    || null : null,
-        pricePerGram: priceVal,
+        pricePerSpool: priceVal,
       });
       onSuccess();
     } catch (err: unknown) {
@@ -263,16 +263,16 @@ function ApproveSection({
       <div className="flex items-end gap-3 flex-wrap">
         <div>
           <label className={`${mono.className} block text-[8px] uppercase tracking-[0.2em] text-red-600 mb-1`}>
-            Price per Gram ($) *
+            Spool Price ($) *
           </label>
           <input
             required
             type="number"
-            step="0.0001"
+            step="0.01"
             min="0"
             value={price}
             onChange={e => setPrice(e.target.value)}
-            placeholder="e.g. 0.0250"
+            placeholder="e.g. 22.99"
             className={`${mono.className} w-48 h-8 bg-surface-alt border border-red-200 px-3 text-[10px] text-text-secondary focus:outline-none focus:border-accent transition-colors placeholder:text-text-muted`}
           />
         </div>
@@ -407,7 +407,7 @@ export default function IntakeDetailPage() {
       setCorrBatchOrLot(intake.draftBatchOrLot               ?? '');
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [intake?.id, intake?.extractedAtUtc]);
+  }, [intake?.id]);
 
   async function handleRetrigger() {
     setRetriggering(true);

--- a/src/web/lib/api/intake.ts
+++ b/src/web/lib/api/intake.ts
@@ -103,7 +103,7 @@ export interface ApproveIntakeRequest {
   correctedSpoolWeightGrams?: number | null;
   correctedPrintSettingsHints?: string | null;
   correctedBatchOrLot?: string | null;
-  pricePerGram: number;
+  pricePerSpool: number;
 }
 
 export interface ApproveIntakeResponse {


### PR DESCRIPTION
## Change
Reviewers enter the total price paid for the spool rather than a per-gram cost. The service derives `PricePerGram = PricePerSpool / effectiveSpoolWeight` at approval time.

If spool weight is unknown or zero at the time of approval a `BusinessRuleException` is thrown — the reviewer must provide a corrected spool weight first.

## Files
- `IntakeDTOs.cs` — `PricePerGram` → `PricePerSpool` on `ApproveIntakeRequest`
- `MaterialIntakeService.cs` — division at approval; both values logged in intake event
- `MaterialIntakeServiceTests.cs` — test values updated (37.50 and 70.00)
- `intake.ts` — TypeScript interface updated
- `admin/intake/[id]/page.tsx` — label, placeholder, step, validation updated