### PR TITLE
chore: Add workflow_dispatch trigger to API workflow

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -8,6 +8,7 @@ on:
       - '.github/workflows/api.yml'
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 env:
   DOTNET_VERSION: '10.0.x'


### PR DESCRIPTION
Allows manual deployment triggering when a merge doesn't fire the path filter.