### PR TITLE
feat: add create buttons to orders and quotes list pages

### DIFF
--- a/src/web/app/(dashboard)/orders/page.tsx
+++ b/src/web/app/(dashboard)/orders/page.tsx
@@ -6,7 +6,7 @@ import { useQuery } from '@tanstack/react-query';
 import { ordersApi } from '@/lib/api/orders';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useRequireAuth } from '@/lib/hooks/use-require-auth';
-import { Package } from 'lucide-react';
+import { Package, Plus } from 'lucide-react';
 import { formatStatus } from '@/lib/utils';
 
 
@@ -67,16 +67,25 @@ export default function OrdersPage() {
     <div className="p-8">
 
       {/* Header */}
-      <div className="mb-8">
-        <p className={`${mono.className} text-[9px] uppercase tracking-[0.2em] text-amber-400/70 mb-2`}>
-          Orders
-        </p>
-        <h1 className={`${display.className} text-4xl text-text-primary tracking-wide`}>
-          My Orders
-        </h1>
-        <p className={`${mono.className} text-[11px] text-text-muted mt-1`}>
-          Track and manage your 3D printing orders
-        </p>
+      <div className="mb-8 flex items-end justify-between">
+        <div>
+          <p className={`${mono.className} text-[9px] uppercase tracking-[0.2em] text-amber-400/70 mb-2`}>
+            Orders
+          </p>
+          <h1 className={`${display.className} text-4xl text-text-primary tracking-wide`}>
+            My Orders
+          </h1>
+          <p className={`${mono.className} text-[11px] text-text-muted mt-1`}>
+            Track and manage your 3D printing orders
+          </p>
+        </div>
+        <button
+          onClick={() => router.push('/orders/new')}
+          className={`${mono.className} flex items-center gap-2 h-9 px-4 bg-amber-500 border border-amber-400/30 text-[9px] uppercase tracking-[0.15em] text-amber-700 hover:bg-amber-400 transition-colors`}
+        >
+          <Plus className="h-3 w-3" />
+          New Order
+        </button>
       </div>
 
       {/* Flash */}
@@ -117,9 +126,16 @@ export default function OrdersPage() {
         {!isLoading && !isError && orders.length === 0 && (
           <div className="px-4 py-12 text-center">
             <Package className="h-8 w-8 text-text-muted mx-auto mb-3" />
-            <p className={`${mono.className} text-[10px] text-text-muted`}>
-              No orders yet — upload a model to get started.
+            <p className={`${mono.className} text-[10px] text-text-muted mb-4`}>
+              No orders yet — place your first one.
             </p>
+            <button
+              onClick={() => router.push('/orders/new')}
+              className={`${mono.className} inline-flex items-center gap-2 h-9 px-4 bg-amber-500 border border-amber-400/30 text-[9px] uppercase tracking-[0.15em] text-amber-700 hover:bg-amber-400 transition-colors`}
+            >
+              <Plus className="h-3 w-3" />
+              New Order
+            </button>
           </div>
         )}
 

--- a/src/web/app/(dashboard)/quotes/page.tsx
+++ b/src/web/app/(dashboard)/quotes/page.tsx
@@ -6,7 +6,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { quotesApi } from '@/lib/api/quotes';
 import { useRequireAuth } from '@/lib/hooks/use-require-auth';
-import { FileText } from 'lucide-react';
+import { FileText, Plus } from 'lucide-react';
 import { formatStatus } from '@/lib/utils';
 
 
@@ -63,16 +63,25 @@ export default function QuotesPage() {
     <div className="p-8">
 
       {/* Header */}
-      <div className="mb-8">
-        <p className={`${mono.className} text-[9px] uppercase tracking-[0.2em] text-accent/70 mb-2`}>
-          Quotes
-        </p>
-        <h1 className={`${display.className} text-4xl text-text-primary tracking-wide`}>
-          My Quotes
-        </h1>
-        <p className={`${mono.className} text-[11px] text-text-muted mt-1`}>
-          Request and track pricing for your projects
-        </p>
+      <div className="mb-8 flex items-end justify-between">
+        <div>
+          <p className={`${mono.className} text-[9px] uppercase tracking-[0.2em] text-accent/70 mb-2`}>
+            Quotes
+          </p>
+          <h1 className={`${display.className} text-4xl text-text-primary tracking-wide`}>
+            My Quotes
+          </h1>
+          <p className={`${mono.className} text-[11px] text-text-muted mt-1`}>
+            Request and track pricing for your projects
+          </p>
+        </div>
+        <button
+          onClick={() => router.push('/quotes/new')}
+          className={`${mono.className} flex items-center gap-2 h-9 px-4 bg-amber-500 border border-amber-400/30 text-[9px] uppercase tracking-[0.15em] text-amber-700 hover:bg-amber-400 transition-colors`}
+        >
+          <Plus className="h-3 w-3" />
+          New Quote
+        </button>
       </div>
 
       {/* Flash */}
@@ -113,9 +122,16 @@ export default function QuotesPage() {
         {!isLoading && !isError && quotes.length === 0 && (
           <div className="px-4 py-12 text-center">
             <FileText className="h-8 w-8 text-text-muted mx-auto mb-3" />
-            <p className={`${mono.className} text-[10px] text-text-muted`}>
-              No quote requests yet — upload a model to get started.
+            <p className={`${mono.className} text-[10px] text-text-muted mb-4`}>
+              No quote requests yet — submit your first one.
             </p>
+            <button
+              onClick={() => router.push('/quotes/new')}
+              className={`${mono.className} inline-flex items-center gap-2 h-9 px-4 bg-amber-500 border border-amber-400/30 text-[9px] uppercase tracking-[0.15em] text-amber-700 hover:bg-amber-400 transition-colors`}
+            >
+              <Plus className="h-3 w-3" />
+              New Quote
+            </button>
           </div>
         )}
 


### PR DESCRIPTION
## Summary

Closes #74

Adds "New Order" and "New Quote" buttons to the respective list pages, reducing friction for one of the most common customer actions on the platform.

## Changes

- **Orders list page** (`/orders`): Added "New Order" button to the page header, aligned right alongside the title. Updated the empty state to include a CTA button.
- **Quotes list page** (`/quotes`): Added "New Quote" button to the page header, aligned right alongside the title. Updated the empty state to include a CTA button.

## Notes

- UI-only change — no API or data model changes
- Both buttons route to the existing `/orders/new` and `/quotes/new` flows
- Styled with the amber primary button pattern consistent with the rest of the app
- `Plus` icon from `lucide-react` added to both button imports

## Acceptance Criteria

- [x] A "New Order" button is visible in the header of the orders list page
- [x] A "New Quote" button is visible in the header of the quotes list page
- [x] Clicking either button navigates to the correct creation flow
- [x] Buttons are styled consistently with the rest of the UI
- [x] Both list pages show an empty-state call-to-action when no records exist