### PR TITLE
fix: buffer non-seekable Azure blob stream before STL parsing

### DIFF
--- a/src/api/PrintHub.Infrastructure/Services/StlAnalyzerService.cs
+++ b/src/api/PrintHub.Infrastructure/Services/StlAnalyzerService.cs
@@ -10,7 +10,7 @@ public class StlAnalyzerService : IStlAnalyzerService
 {
     private readonly ILogger<StlAnalyzerService> _logger;
 
-    // ── Physical constants ──────────────────────────────────────────────────
+    // ── Physical constants ────────────────────────────────────────────────────────
     // PLA density in g/cm³ — used for weight estimation.
     // A future improvement could pull density from material PrintSettings.
     private const decimal PlaDensity = 1.24m;
@@ -30,7 +30,7 @@ public class StlAnalyzerService : IStlAnalyzerService
     // Overhead per print: heat-up, homing, skirt, cooling = ~8 minutes.
     private const decimal OverheadMinutes = 8m;
 
-    // ── Configurable default print speed ───────────────────────────────────
+    // ── Configurable default print speed ───────────────────────────────────────────
     // Pulled from FileAnalysis:DefaultPrintSpeedMmPerSec in appsettings.
     // Falls back to 50 mm/s — a conservative CR-10 FDM speed.
     // Individual materials override this via their PrintSettings JSONB,
@@ -49,7 +49,19 @@ public class StlAnalyzerService : IStlAnalyzerService
     {
         try
         {
-            var triangles = await ParseStlAsync(fileStream, fileName);
+            // Azure Blob download streams (RetriableStream) are neither seekable nor
+            // Length-aware. Buffer into a MemoryStream before parsing so that
+            // ParseStlAsync can call stream.Length and stream.Seek freely.
+            Stream parseStream = fileStream;
+            if (!fileStream.CanSeek)
+            {
+                var ms = new MemoryStream();
+                await fileStream.CopyToAsync(ms);
+                ms.Seek(0, SeekOrigin.Begin);
+                parseStream = ms;
+            }
+
+            var triangles = await ParseStlAsync(parseStream, fileName);
             if (triangles.Count == 0)
                 return null;
 
@@ -139,7 +151,7 @@ public class StlAnalyzerService : IStlAnalyzerService
         return Math.Round(totalSeconds / 3600m, 2);
     }
 
-    // ── STL parsing (unchanged) ─────────────────────────────────────────────
+    // ── STL parsing (unchanged) ────────────────────────────────────────────────────
 
     private static async Task<List<(Vector3 v1, Vector3 v2, Vector3 v3)>> ParseStlAsync(
         Stream stream, string fileName)
@@ -219,7 +231,7 @@ public class StlAnalyzerService : IStlAnalyzerService
         return triangles;
     }
 
-    // ── Geometry helpers (unchanged) ────────────────────────────────────────
+    // ── Geometry helpers (unchanged) ──────────────────────────────────────────────────
 
     private static decimal CalculateVolume(List<(Vector3 v1, Vector3 v2, Vector3 v3)> triangles)
     {


### PR DESCRIPTION
## Problem

After a chunked upload completes, `FileService` downloads the blob from Azure to run STL analysis. The Azure SDK returns a `RetriableStream` which does not support `.Length` or `.Seek`. `ParseStlAsync` calls both to detect binary vs ASCII format, causing:

```
System.NotSupportedException: Specified method is not supported.
   at Azure.Core.Pipeline.RetriableStream.RetriableStreamImpl.get_Length()
   at PrintHub.Infrastructure.Services.StlAnalyzerService.ParseStlAsync(Stream stream, ...) line 157
```

The upload itself succeeded (201 returned) and the file was saved to the DB, but the analysis result was `null`, so no volume/weight/print-time estimates were stored.

## Fix

In `AnalyzeAsync`, check `fileStream.CanSeek` before calling `ParseStlAsync`. If the stream is not seekable (Azure blob download), copy it into a `MemoryStream` first. The buffer is bounded by the uploaded file size — files are already capped at 250 MB at the upload layer, and typical STL files are well under that.

```csharp
Stream parseStream = fileStream;
if (!fileStream.CanSeek)
{
    var ms = new MemoryStream();
    await fileStream.CopyToAsync(ms);
    ms.Seek(0, SeekOrigin.Begin);
    parseStream = ms;
}
var triangles = await ParseStlAsync(parseStream, fileName);
```

`ParseStlAsync` itself is unchanged — it still calls `.Length` and `.Seek` as before, which is correct now that it always receives a seekable stream.

## Testing

- Upload an STL via the frontend → confirm `FileUploadCompleteResponse` includes populated `analysis` fields (volume, dimensions, triangle count, print time estimate)
- Upload a non-STL file → confirm analysis returns null gracefully (existing behaviour)
