### PR TITLE
fix(quotes): reshape quote request payload to match backend DTO

### DIFF
--- a/src/web/app/(dashboard)/quotes/new/page.tsx
+++ b/src/web/app/(dashboard)/quotes/new/page.tsx
@@ -84,16 +84,28 @@ export default function NewQuotePage() {
     });
 
   const onSubmit = async (values: QuoteFormValues) => {
+    if (!fileId) return;
+
+    // Normalize optional string fields: empty strings from form inputs must be
+    // sent as undefined so they omit cleanly from the JSON payload — the
+    // backend expects Guid?/DateTime?/string? and rejects empty strings.
+    const materialId     = values.preferredMaterialId?.trim() || undefined;
+    const requiredByDate = values.requiredByDate?.trim() || undefined;
+    const specialReqs    = values.specialRequirements?.trim() || undefined;
+    const notes          = values.notes?.trim() || undefined;
+
     try {
       const response = await quotesApi.create({
-        fileId:              fileId ?? undefined,
-        quantity:            values.quantity,
-        preferredMaterialId: values.preferredMaterialId,
-        requiredByDate:      values.requiredByDate,
-        specialRequirements: values.specialRequirements,
-        notes:               values.notes,
-        budgetMin:           values.budgetMin,
-        budgetMax:           values.budgetMax,
+        files: [{
+          fileId,
+          materialId,
+          quantity: values.quantity,
+        }],
+        requiredByDate,
+        specialRequirements: specialReqs,
+        notes,
+        budgetMin: values.budgetMin,
+        budgetMax: values.budgetMax,
       });
       router.push(`/quotes?created=${response.data.id}`);
     } catch {

--- a/src/web/lib/api/quotes.ts
+++ b/src/web/lib/api/quotes.ts
@@ -57,14 +57,19 @@ export interface QuoteAnalytics {
   quoteOriginatedRevenueShare: number | null;
 }
 
-export interface CreateQuoteRequest {
-  fileId?: string;
+export interface QuoteFileItemRequest {
+  fileId: string;
+  materialId?: string;
   quantity: number;
-  preferredMaterialId?: string;
-  preferredColor?: string;
+  color?: string;
+}
+
+export interface CreateQuoteRequest {
+  files: QuoteFileItemRequest[];
   requiredByDate?: string;
   specialRequirements?: string;
   notes?: string;
+  budgetRange?: string;
   budgetMin?: number;
   budgetMax?: number;
 }


### PR DESCRIPTION
## What changed

The quote submission form was posting a flat `{ fileId, quantity, preferredMaterialId, ... }` payload to `POST /api/v1/Quotes`, but the backend `CreateQuoteRequest` DTO has expected a `{ files: [{ fileId, materialId, quantity, color }], ... }` shape ever since the multi-file upload refactor in #72. FluentValidation's `RuleFor(x => x.Files).NotEmpty()` rejected every submission with 400 Bad Request.

- Added `QuoteFileItemRequest` interface in `src/web/lib/api/quotes.ts`
- Reshaped `CreateQuoteRequest` to wrap file/material/quantity in a `files` array, matching the C# record
- Updated `src/web/app/(dashboard)/quotes/new/page.tsx` `onSubmit` to build the nested payload
- Normalize empty-string optional fields (`preferredMaterialId`, `requiredByDate`, `specialRequirements`, `notes`) to `undefined` so `Guid?` / `DateTime?` JSON binding doesn't fail on empty inputs (e.g. when "No preference" is selected for material)
- Guard `onSubmit` against a missing `fileId`

Audited the orders flow as part of this — `ordersApi.create` / `ordersApi.update` and both `orders/new` and `orders/[id]/edit` pages already wrap submissions in `items: [{...}]`, so no changes were needed there.

## Related issue

Fixes #72

## Type of change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `chore` — refactor, deps, tooling (no behaviour change)
- [ ] `docs` — documentation only

## How to test

1. Check out this branch and run the API + web locally (`docker compose up -d`, `dotnet run` in `src/api/PrintHub.API`, `npm run dev` in `src/web`).
2. Log in as a regular user.
3. Upload a `.stl` file from the dashboard.
4. On the file's detail page, click **Request a Quote**.
5. Leave defaults (quantity 1, no preferred material, no dates, no budget) and click **Submit Quote Request**.
6. Expected: redirected to `/quotes?created=<id>` with the new quote visible in the list.
7. Before this fix, the same flow returned 400 Bad Request with `"Files": ["At least one file is required."]`.

Also re-verify on the orders flow:
1. From a file detail page, start a new order.
2. Submit with a selected material and quantity.
3. Expected: order creates successfully (regression check — no shape change here).

## Checklist

- [x] CI passes (build, lint, tests) — `npx tsc --noEmit` runs clean on `src/web`
- [x] No hardcoded secrets or credentials
- [x] New environment variables documented in `appsettings.json` / `.env.example` — none added
- [x] Database migrations included if schema changed — no schema change